### PR TITLE
Quil program to Cirq circuit conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/generated
 
 # Default pycharm virtual env
 .venv/
+
+# pyenv configuration
+.python-version

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -358,3 +358,24 @@ def test_pauli_interaction_gate():
 
 CZ 0 1
 """
+
+
+def test_equivalent_unitaries():
+    """This test covers the factor of pi change. However, it will be skipped
+    if pyquil is unavailable for import."""
+    pyquil = pytest.importorskip("pyquil")
+    pyquil_simulation_tools = pytest.importorskip("pyquil.simulation.tools")
+    q0, q1 = _make_qubits(2)
+    operations = [
+        cirq.XPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.YPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.ZPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.CZPowGate(exponent=0.5)(q0, q1),
+        cirq.ISwapPowGate(exponent=0.5)(q0, q1),
+    ]
+    output = cirq.QuilOutput(operations, (q0, q1))
+    program = pyquil.Program(str(output))
+    pyquil_unitary = pyquil_simulation_tools.program_unitary(program, n_qubits=2)
+    # Qubit ordering differs between pyQuil and Cirq.
+    cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations, cirq.SWAP(q0, q1)).unitary()
+    assert np.allclose(pyquil_unitary, cirq_unitary)

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -368,7 +368,9 @@ def test_equivalent_unitaries():
     ]
     output = cirq.QuilOutput(operations, (q0, q1))
     program = pyquil.Program(str(output))
-    pyquil_unitary = pyquil_simulation_tools.program_unitary(program, n_qubits=2)
+    pyquil_unitary = pyquil_simulation_tools.program_unitary(program,
+                                                             n_qubits=2)
     # Qubit ordering differs between pyQuil and Cirq.
-    cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations, cirq.SWAP(q0, q1)).unitary()
+    cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations,
+                                cirq.SWAP(q0, q1)).unitary()
     assert np.allclose(pyquil_unitary, cirq_unitary)

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -38,7 +38,7 @@ def test_single_gate_with_parameter():
     output = cirq.QuilOutput((cirq.X(q0)**0.5,), (q0,))
     assert (str(output) == f"""# Created using Cirq.
 
-RX({np.pi/2}) 0\n""")
+RX({np.pi / 2}) 0\n""")
 
 
 def test_single_gate_named_qubit():
@@ -54,9 +54,9 @@ def test_h_gate_with_parameter():
     output = cirq.QuilOutput((cirq.H(q0)**0.25,), (q0,))
     assert (str(output) == f"""# Created using Cirq.
 
-RY({np.pi/4}) 0
-RX({np.pi/4}) 0
-RY({-np.pi/4}) 0\n""")
+RY({np.pi / 4}) 0
+RX({np.pi / 4}) 0
+RY({-np.pi / 4}) 0\n""")
 
 
 def test_save_to_file(tmpdir):
@@ -189,9 +189,9 @@ def test_i_swap_with_power():
 CNOT 0 1
 H 0
 CNOT 1 0
-RZ({np.pi/8}) 0
+RZ({np.pi / 8}) 0
 CNOT 1 0
-RZ({-np.pi/8}) 0
+RZ({-np.pi / 8}) 0
 H 0
 CNOT 0 1
 """
@@ -209,83 +209,83 @@ DECLARE m2 BIT[1]
 DECLARE m3 BIT[3]
 
 Z 0
-RZ({5*np.pi/8}) 0
+RZ({5 * np.pi / 8}) 0
 Y 0
-RY({3*np.pi/8}) 0
+RY({3 * np.pi / 8}) 0
 X 0
-RX({7*np.pi/8}) 0
+RX({7 * np.pi / 8}) 0
 H 1
 CZ 0 1
-CPHASE({np.pi/4}) 0 1
+CPHASE({np.pi / 4}) 0 1
 CNOT 0 1
-RY({-np.pi/2}) 1
-CPHASE({np.pi/2}) 0 1
-RY({np.pi/2}) 1
+RY({-np.pi / 2}) 1
+CPHASE({np.pi / 2}) 0 1
+RY({np.pi / 2}) 1
 SWAP 0 1
-PSWAP({3*np.pi/4}) 0 1
+PSWAP({3 * np.pi / 4}) 0 1
 H 2
 CCNOT 0 1 2
 H 2
 CCNOT 0 1 2
-RZ({np.pi/8}) 0
-RZ({np.pi/8}) 1
-RZ({np.pi/8}) 2
+RZ({np.pi / 8}) 0
+RZ({np.pi / 8}) 1
+RZ({np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 1
-RZ({np.pi/8}) 2
+RZ({-np.pi / 8}) 1
+RZ({np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 2
+RZ({-np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 2
+RZ({-np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
 H 2
-RZ({np.pi/8}) 0
-RZ({np.pi/8}) 1
-RZ({np.pi/8}) 2
+RZ({np.pi / 8}) 0
+RZ({np.pi / 8}) 1
+RZ({np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 1
-RZ({np.pi/8}) 2
+RZ({-np.pi / 8}) 1
+RZ({np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 2
+RZ({-np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ({-np.pi/8}) 2
+RZ({-np.pi / 8}) 2
 CNOT 0 1
 CNOT 1 2
 H 2
 CSWAP 0 1 2
 X 0
 X 1
-RX({3*np.pi/4}) 0
-RX({3*np.pi/4}) 1
+RX({3 * np.pi / 4}) 0
+RX({3 * np.pi / 4}) 1
 Y 0
 Y 1
-RY({3*np.pi/4}) 0
-RY({3*np.pi/4}) 1
+RY({3 * np.pi / 4}) 0
+RY({3 * np.pi / 4}) 1
 Z 0
 Z 1
-RZ({3*np.pi/4}) 0
-RZ({3*np.pi/4}) 1
+RZ({3 * np.pi / 4}) 0
+RZ({3 * np.pi / 4}) 1
 I 0
 I 0
 I 1
 I 2
 ISWAP 2 0
-RZ({-0.111*np.pi}) 1
-RX({np.pi/4}) 1
-RZ({0.111*np.pi}) 1
-RZ({-0.333*np.pi}) 1
-RX({np.pi/2}) 1
-RZ({0.333*np.pi}) 1
-RZ({-0.777*np.pi}) 1
-RX({-np.pi/2}) 1
-RZ({0.777*np.pi}) 1
+RZ({-0.111 * np.pi}) 1
+RX({np.pi / 4}) 1
+RZ({0.111 * np.pi}) 1
+RZ({-0.333 * np.pi}) 1
+RX({np.pi / 2}) 1
+RZ({0.333 * np.pi}) 1
+RZ({-0.777 * np.pi}) 1
+RX({-np.pi / 2}) 1
+RZ({0.777 * np.pi}) 1
 WAIT
 MEASURE 0 m0[0]
 MEASURE 2 m1[0]

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -36,9 +36,9 @@ X 0\n""")
 def test_single_gate_with_parameter():
     q0, = _make_qubits(1)
     output = cirq.QuilOutput((cirq.X(q0)**0.5,), (q0,))
-    assert (str(output) == """# Created using Cirq.
+    assert (str(output) == f"""# Created using Cirq.
 
-RX(0.5) 0\n""")
+RX({np.pi/2}) 0\n""")
 
 
 def test_single_gate_named_qubit():
@@ -52,11 +52,11 @@ X 0\n""")
 def test_h_gate_with_parameter():
     q0, = _make_qubits(1)
     output = cirq.QuilOutput((cirq.H(q0)**0.25,), (q0,))
-    assert (str(output) == """# Created using Cirq.
+    assert (str(output) == f"""# Created using Cirq.
 
-RY(0.25) 0
-RX(0.25) 0
-RY(-0.25) 0\n""")
+RY({np.pi/4}) 0
+RX({np.pi/4}) 0
+RY({-np.pi/4}) 0\n""")
 
 
 def test_save_to_file(tmpdir):
@@ -184,14 +184,14 @@ def test_i_swap_with_power():
         q0,
         q1,
     ))
-    assert str(output) == """# Created using Cirq.
+    assert str(output) == f"""# Created using Cirq.
 
 CNOT 0 1
 H 0
 CNOT 1 0
-RZ(0.125) 0
+RZ({np.pi/8}) 0
 CNOT 1 0
-RZ(-0.125) 0
+RZ({-np.pi/8}) 0
 H 0
 CNOT 0 1
 """
@@ -201,7 +201,7 @@ def test_all_operations():
     qubits = tuple(_make_qubits(5))
     operations = _all_operations(*qubits, include_measurements=False)
     output = cirq.QuilOutput(operations, qubits)
-    assert (str(output) == """# Created using Cirq.
+    assert (str(output) == f"""# Created using Cirq.
 
 DECLARE m0 BIT[1]
 DECLARE m1 BIT[1]
@@ -209,83 +209,83 @@ DECLARE m2 BIT[1]
 DECLARE m3 BIT[3]
 
 Z 0
-RZ(0.625) 0
+RZ({5*np.pi/8}) 0
 Y 0
-RY(0.375) 0
+RY({3*np.pi/8}) 0
 X 0
-RX(0.875) 0
+RX({7*np.pi/8}) 0
 H 1
 CZ 0 1
-CPHASE(0.25) 0 1
+CPHASE({np.pi/4}) 0 1
 CNOT 0 1
-RY(-0.5) 1
-CPHASE(0.5) 0 1
-RY(0.5) 1
+RY({-np.pi/2}) 1
+CPHASE({np.pi/2}) 0 1
+RY({np.pi/2}) 1
 SWAP 0 1
-PSWAP(0.75) 0 1
+PSWAP({3*np.pi/4}) 0 1
 H 2
 CCNOT 0 1 2
 H 2
 CCNOT 0 1 2
-RZ(0.125) 0
-RZ(0.125) 1
-RZ(0.125) 2
+RZ({np.pi/8}) 0
+RZ({np.pi/8}) 1
+RZ({np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 1
-RZ(0.125) 2
+RZ({-np.pi/8}) 1
+RZ({np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 2
+RZ({-np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 2
+RZ({-np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
 H 2
-RZ(0.125) 0
-RZ(0.125) 1
-RZ(0.125) 2
+RZ({np.pi/8}) 0
+RZ({np.pi/8}) 1
+RZ({np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 1
-RZ(0.125) 2
+RZ({-np.pi/8}) 1
+RZ({np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 2
+RZ({-np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
-RZ(-0.125) 2
+RZ({-np.pi/8}) 2
 CNOT 0 1
 CNOT 1 2
 H 2
 CSWAP 0 1 2
 X 0
 X 1
-RX(0.75) 0
-RX(0.75) 1
+RX({3*np.pi/4}) 0
+RX({3*np.pi/4}) 1
 Y 0
 Y 1
-RY(0.75) 0
-RY(0.75) 1
+RY({3*np.pi/4}) 0
+RY({3*np.pi/4}) 1
 Z 0
 Z 1
-RZ(0.75) 0
-RZ(0.75) 1
+RZ({3*np.pi/4}) 0
+RZ({3*np.pi/4}) 1
 I 0
 I 0
 I 1
 I 2
 ISWAP 2 0
-RZ(-0.111) 1
-RX(0.25) 1
-RZ(0.111) 1
-RZ(-0.333) 1
-RX(0.5) 1
-RZ(0.333) 1
-RZ(-0.777) 1
-RX(-0.5) 1
-RZ(0.777) 1
+RZ({-0.111*np.pi}) 1
+RX({np.pi/4}) 1
+RZ({0.111*np.pi}) 1
+RZ({-0.333*np.pi}) 1
+RX({np.pi/2}) 1
+RZ({0.333*np.pi}) 1
+RZ({-0.777*np.pi}) 1
+RX({-np.pi/2}) 1
+RZ({0.777*np.pi}) 1
 WAIT
 MEASURE 0 m0[0]
 MEASURE 2 m1[0]

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -186,14 +186,7 @@ def test_i_swap_with_power():
     ))
     assert str(output) == f"""# Created using Cirq.
 
-CNOT 0 1
-H 0
-CNOT 1 0
-RZ({np.pi / 8}) 0
-CNOT 1 0
-RZ({-np.pi / 8}) 0
-H 0
-CNOT 0 1
+XY({np.pi / 4}) 0 1
 """
 
 

--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -2,3 +2,4 @@
 
 ply>=3.4
 pylatex~=1.3.0
+pyquil~=2.19

--- a/cirq/contrib/quil_import/__init__.py
+++ b/cirq/contrib/quil_import/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cirq.contrib.quil_import.quil import circuit_from_quil

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -88,8 +88,12 @@ def cphase00(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE00 gate of given angle.
     """
-    cphase00_matrix = np.array([[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0],
-                                [0, 0, 1, 0], [0, 0, 0, 1]])
+    cphase00_matrix = np.array([
+        [np.exp(1j * phi), 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1]
+    ], dtype=complex)
     return MatrixGate(cphase00_matrix)
 
 
@@ -102,8 +106,12 @@ def cphase01(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE01 gate of given angle.
     """
-    cphase01_matrix = np.array([[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0],
-                                [0, 0, 1, 0], [0, 0, 0, 1]])
+    cphase01_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, np.exp(1j * phi), 0, 0],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1]
+    ], dtype=complex)
     return MatrixGate(cphase01_matrix)
 
 
@@ -116,8 +124,12 @@ def cphase10(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE10 gate of given angle.
     """
-    cphase10_matrix = np.array([[1, 0, 0, 0], [0, 1, 0, 0],
-                                [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]])
+    cphase10_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, np.exp(1j * phi), 0],
+        [0, 0, 0, 1]
+    ], dtype=complex)
     return MatrixGate(cphase10_matrix)
 
 
@@ -148,7 +160,7 @@ def pswap(phi: float) -> MatrixGate:
         [0, 0, np.exp(1j * phi), 0],
         [0, np.exp(1j * phi), 0, 0],
         [0, 0, 0, 1],
-    ])
+    ], dtype=complex)
     return MatrixGate(pswap_matrix)
 
 

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -231,7 +231,7 @@ def circuit_from_quil(quil: str) -> Circuit:
         https://github.com/rigetti/pyquil
     """
     circuit = Circuit()
-    defgates = {}
+    defined_gates = SUPPORTED_GATES.copy()
     instructions = parse(quil)
 
     for inst in instructions:
@@ -240,7 +240,7 @@ def circuit_from_quil(quil: str) -> Circuit:
             if inst.parameters:
                 raise UnsupportedQuilInstruction(
                     "Parameterized DEFGATEs are currently unsupported.")
-            defgates[inst.name] = MatrixGate(inst.matrix)
+            defined_gates[inst.name] = MatrixGate(inst.matrix)
 
         # Pass when encountering a DECLARE.
         elif isinstance(inst, Declare):
@@ -251,11 +251,10 @@ def circuit_from_quil(quil: str) -> Circuit:
             quil_gate_name = inst.name
             quil_gate_params = inst.params
             line_qubits = list(LineQubit(q.index) for q in inst.qubits)
-            defgates_and_supported_gates = dict(**defgates, **SUPPORTED_GATES)
-            if quil_gate_name not in defgates_and_supported_gates:
+            if quil_gate_name not in defined_gates:
                 raise UndefinedQuilGate(
                     f"Quil gate {quil_gate_name} not supported in Cirq.")
-            cirq_gate_fn = defgates_and_supported_gates[quil_gate_name]
+            cirq_gate_fn = defined_gates[quil_gate_name]
             if quil_gate_params:
                 circuit += cirq_gate_fn(*quil_gate_params)(*line_qubits)
             else:

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -1,0 +1,161 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from functools import singledispatch
+from typing import Callable, Mapping, Union
+
+import numpy as np
+from pyquil.parser import parse
+from pyquil.quilbase import (Declare,
+                             Gate as PyQuilGate,
+                             Measurement as PyQuilMeasurement,
+                             Pragma,
+                             Reset,
+                             ResetQubit)
+
+from cirq import Circuit, LineQubit
+from cirq.ops import (CCNOT, CNOT, CSWAP, CZ, CZPowGate, Gate, H, I, ISWAP,
+                      ISwapPowGate, MeasurementGate, S, SWAP, T, X, Y, Z,
+                      ZPowGate, rx, ry, rz)
+
+
+class UnsupportedQuilGate(Exception):
+    pass
+
+
+def cphase(param: float) -> CZPowGate:
+    """
+    PyQuil's CPHASE and Cirq's CZPowGate are the same up to a factor of pi.
+    """
+    return CZPowGate(exponent=param / np.pi)
+
+
+def phase(param: float) -> ZPowGate:
+    """
+    PyQuil's PHASE and Cirq's ZPowGate are the same up to a factor of pi.
+    """
+    return ZPowGate(exponent=param / np.pi)
+
+
+def xy(param: float) -> ISwapPowGate:
+    """
+    PyQuil's XY and Cirq's ISwapPowGate are the same up to a factor of pi.
+    """
+    return ISwapPowGate(exponent=param / np.pi)
+
+
+# parameterized gates map to functions that produce Gate objects
+SUPPORTED_GATES: Mapping[str, Union[Gate, Callable[..., Gate]]] = {
+    "CCNOT": CCNOT,
+    "CNOT": CNOT,
+    "CSWAP": CSWAP,
+    "CPHASE": cphase,
+    "CZ": CZ,
+    "PHASE": phase,
+    "H": H,
+    "I": I,
+    "ISWAP": ISWAP,
+    "RX": rx,
+    "RY": ry,
+    "RZ": rz,
+    "S": S,
+    "SWAP": SWAP,
+    "T": T,
+    "X": X,
+    "Y": Y,
+    "Z": Z,
+    "XY": xy,
+}
+
+
+@singledispatch
+def op_from_inst(inst: object) -> None:
+    """
+    Generic function for converting pyQuil instructions to Cirq operations.
+    """
+    raise TypeError(f"Quil instruction {inst} of type {type(inst)} not currently supported in Cirq.")
+
+
+@op_from_inst.register
+def _(inst: PyQuilGate) -> Gate:
+    """
+    Convert pyQuil gates to Cirq operations.
+    """
+    quil_gate_name = inst.name
+    quil_gate_params = inst.params
+    line_qubits = list(LineQubit(q.index) for q in inst.qubits)
+
+    if quil_gate_name in SUPPORTED_GATES:
+        cirq_gate_fn = SUPPORTED_GATES[quil_gate_name]
+        if quil_gate_params:
+            return cirq_gate_fn(*quil_gate_params)(*line_qubits)
+        return cirq_gate_fn(*line_qubits)
+    raise UnsupportedQuilGate(f"Quil gate {quil_gate_name} not supported in Cirq.")
+
+
+@op_from_inst.register
+def _(inst: PyQuilMeasurement) -> MeasurementGate:
+    """
+    Convert pyQuil MEASURE operations to Cirq MeasurementGate objects.
+    """
+    line_qubit = LineQubit(inst.qubit.index)
+    quil_memory_reference = inst.classical_reg.out()
+    return MeasurementGate(1, key=quil_memory_reference)(line_qubit)
+
+
+@op_from_inst.register
+def _(inst: Declare) -> Circuit:
+    """
+    Pass when encountering a DECLARE.
+    """
+    return Circuit()
+
+
+@op_from_inst.register
+def _(inst: Pragma) -> Circuit:
+    """
+    Pass and warn when encountering a PRAGMA.
+    """
+    warnings.warn(f"Ignoring unsupported operation {inst}")
+    return Circuit()
+
+
+@op_from_inst.register
+def _(inst: Reset) -> Circuit:
+    """
+    Pass and warn when encountering a RESET.
+    """
+    warnings.warn(f"Ignoring unsupported operation {inst}")
+    return Circuit()
+
+
+@op_from_inst.register
+def _(inst: ResetQubit) -> Circuit:
+    """
+    Pass and warn when encountering a RESET q.
+    """
+    warnings.warn(f"Ignoring unsupported operation {inst}")
+    return Circuit()
+
+
+def circuit_from_quil(quil: str) -> Circuit:
+    """
+    Convert a Quil program to a Cirq Circuit.
+    """
+    circuit = Circuit()
+    instructions = parse(quil)
+    for inst in instructions:
+        circuit += op_from_inst(inst)
+    return circuit

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -67,8 +67,9 @@ class UnsupportedQuilInstruction(Exception):
 
 
 def cphase(param: float) -> CZPowGate:
-    """The angle parameter of pyQuil's CPHASE gate and the exponent of
-    Cirq's CZPowGate differ by a factor of pi.
+    """Returns a controlled-phase gate as a Cirq CZPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's CPHASE
+    gate and the exponent of Cirq's CZPowGate differ by a factor of pi.
 
     Args:
         param: Gate parameter (in radians).
@@ -80,7 +81,7 @@ def cphase(param: float) -> CZPowGate:
 
 
 def cphase00(phi: float) -> MatrixGate:
-    """PyQuil's CPHASE00 gate can be defined using Cirq's MatrixGate.
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE00 gate.
 
     Args:
         phi: Gate parameter (in radians).
@@ -98,7 +99,7 @@ def cphase00(phi: float) -> MatrixGate:
 
 
 def cphase01(phi: float) -> MatrixGate:
-    """PyQuil's CPHASE01 gate can be defined using Cirq's MatrixGate.
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE01 gate.
 
     Args:
         phi: Gate parameter (in radians).
@@ -116,7 +117,7 @@ def cphase01(phi: float) -> MatrixGate:
 
 
 def cphase10(phi: float) -> MatrixGate:
-    """PyQuil's CPHASE10 gate can be defined using Cirq's MatrixGate.
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE10 gate.
 
     Args:
         phi: Gate parameter (in radians).
@@ -134,8 +135,9 @@ def cphase10(phi: float) -> MatrixGate:
 
 
 def phase(param: float) -> ZPowGate:
-    """The angle parameter of pyQuil's PHASE gate and the exponent of
-    Cirq's ZPowGate differ by a factor of pi.
+    """Returns a single-qubit phase gate as a Cirq ZPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's PHASE
+    gate and the exponent of Cirq's ZPowGate differ by a factor of pi.
 
     Args:
         param: Gate parameter (in radians).
@@ -147,7 +149,7 @@ def phase(param: float) -> ZPowGate:
 
 
 def pswap(phi: float) -> MatrixGate:
-    """PyQuil's PSWAP gate can be defined using Cirq's MatrixGate.
+    """Returns a Cirq MatrixGate for pyQuil's PSWAP gate.
 
     Args:
         phi: Gate parameter (in radians).
@@ -165,8 +167,9 @@ def pswap(phi: float) -> MatrixGate:
 
 
 def xy(param: float) -> ISwapPowGate:
-    """The angle parameter of pyQuil's XY gate and the exponent of
-    Cirq's ISwapPowGate differ by a factor of pi.
+    """Returns an ISWAP-family gate as a Cirq ISwapPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's XY gate
+    and the exponent of Cirq's ISwapPowGate differ by a factor of pi.
 
     Args:
         param: Gate parameter (in radians).

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -77,9 +77,8 @@ def cphase00(phi: float) -> MatrixGate:
     """
     PyQuil's CPHASE00 gate can be defined using Cirq's MatrixGate.
     """
-    cphase00_matrix = np.array(
-        [[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
-    )
+    cphase00_matrix = np.array([[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0],
+                                [0, 0, 1, 0], [0, 0, 0, 1]])
     return MatrixGate(cphase00_matrix)
 
 
@@ -87,9 +86,8 @@ def cphase01(phi: float) -> MatrixGate:
     """
     PyQuil's CPHASE01 gate can be defined using Cirq's MatrixGate.
     """
-    cphase01_matrix = np.array(
-        [[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
-    )
+    cphase01_matrix = np.array([[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0],
+                                [0, 0, 1, 0], [0, 0, 0, 1]])
     return MatrixGate(cphase01_matrix)
 
 
@@ -97,9 +95,8 @@ def cphase10(phi: float) -> MatrixGate:
     """
     PyQuil's CPHASE10 gate can be defined using Cirq's MatrixGate.
     """
-    cphase10_matrix = np.array(
-        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]]
-    )
+    cphase10_matrix = np.array([[1, 0, 0, 0], [0, 1, 0, 0],
+                                [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]])
     return MatrixGate(cphase10_matrix)
 
 
@@ -114,14 +111,12 @@ def pswap(phi: float) -> MatrixGate:
     """
     PyQuil's PSWAP gate can be defined using Cirq's MatrixGate.
     """
-    pswap_matrix = np.array(
-        [
-            [1, 0, 0, 0],
-            [0, 0, np.exp(1j * phi), 0],
-            [0, np.exp(1j * phi), 0, 0],
-            [0, 0, 0, 1],
-        ]
-    )
+    pswap_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, 0, np.exp(1j * phi), 0],
+        [0, np.exp(1j * phi), 0, 0],
+        [0, 0, 0, 1],
+    ])
     return MatrixGate(pswap_matrix)
 
 
@@ -183,8 +178,7 @@ def circuit_from_quil(quil: str) -> Circuit:
         if isinstance(inst, DefGate):
             if inst.parameters:
                 raise UnsupportedQuilInstruction(
-                    "Parameterized DEFGATEs are currently unsupported."
-                )
+                    "Parameterized DEFGATEs are currently unsupported.")
             defgates[inst.name] = MatrixGate(inst.matrix)
 
         # Pass when encountering a DECLARE.
@@ -199,8 +193,7 @@ def circuit_from_quil(quil: str) -> Circuit:
             defgates_and_supported_gates = dict(**defgates, **SUPPORTED_GATES)
             if quil_gate_name not in defgates_and_supported_gates:
                 raise UnsupportedQuilGate(
-                    f"Quil gate {quil_gate_name} not supported in Cirq."
-                )
+                    f"Quil gate {quil_gate_name} not supported in Cirq.")
             cirq_gate_fn = defgates_and_supported_gates[quil_gate_name]
             if quil_gate_params:
                 circuit += cirq_gate_fn(*quil_gate_params)(*line_qubits)
@@ -211,9 +204,7 @@ def circuit_from_quil(quil: str) -> Circuit:
         elif isinstance(inst, PyQuilMeasurement):
             line_qubit = LineQubit(inst.qubit.index)
             quil_memory_reference = inst.classical_reg.out()
-            circuit += MeasurementGate(1, key=quil_memory_reference)(
-                line_qubit
-            )
+            circuit += MeasurementGate(1, key=quil_memory_reference)(line_qubit)
 
         # Raise a targeted error when encountering a PRAGMA.
         elif isinstance(inst, Pragma):
@@ -227,7 +218,6 @@ def circuit_from_quil(quil: str) -> Circuit:
         else:
             raise UnsupportedQuilInstruction(
                 f"Quil instruction {inst} of type {type(inst)}"
-                " not currently supported in Cirq."
-            )
+                " not currently supported in Cirq.")
 
     return circuit

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -53,7 +53,7 @@ from cirq.ops import (
 )
 
 
-class UnsupportedQuilGate(Exception):
+class UndefinedQuilGate(Exception):
     pass
 
 
@@ -250,7 +250,7 @@ def circuit_from_quil(quil: str) -> Circuit:
             line_qubits = list(LineQubit(q.index) for q in inst.qubits)
             defgates_and_supported_gates = dict(**defgates, **SUPPORTED_GATES)
             if quil_gate_name not in defgates_and_supported_gates:
-                raise UnsupportedQuilGate(
+                raise UndefinedQuilGate(
                     f"Quil gate {quil_gate_name} not supported in Cirq.")
             cirq_gate_fn = defgates_and_supported_gates[quil_gate_name]
             if quil_gate_params:

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -89,12 +89,9 @@ def cphase00(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE00 gate of given angle.
     """
-    cphase00_matrix = np.array([
-        [np.exp(1j * phi), 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 0, 1, 0],
-        [0, 0, 0, 1]
-    ], dtype=complex)
+    cphase00_matrix = np.array(
+        [[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+        dtype=complex)
     return MatrixGate(cphase00_matrix)
 
 
@@ -107,12 +104,9 @@ def cphase01(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE01 gate of given angle.
     """
-    cphase01_matrix = np.array([
-        [1, 0, 0, 0],
-        [0, np.exp(1j * phi), 0, 0],
-        [0, 0, 1, 0],
-        [0, 0, 0, 1]
-    ], dtype=complex)
+    cphase01_matrix = np.array(
+        [[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+        dtype=complex)
     return MatrixGate(cphase01_matrix)
 
 
@@ -125,12 +119,9 @@ def cphase10(phi: float) -> MatrixGate:
     Returns:
         A MatrixGate equivalent to a CPHASE10 gate of given angle.
     """
-    cphase10_matrix = np.array([
-        [1, 0, 0, 0],
-        [0, 1, 0, 0],
-        [0, 0, np.exp(1j * phi), 0],
-        [0, 0, 0, 1]
-    ], dtype=complex)
+    cphase10_matrix = np.array(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]],
+        dtype=complex)
     return MatrixGate(cphase10_matrix)
 
 
@@ -162,7 +153,8 @@ def pswap(phi: float) -> MatrixGate:
         [0, 0, np.exp(1j * phi), 0],
         [0, np.exp(1j * phi), 0, 0],
         [0, 0, 0, 1],
-    ], dtype=complex)
+    ],
+                            dtype=complex)
     return MatrixGate(pswap_matrix)
 
 

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -67,15 +67,26 @@ class UnsupportedQuilInstruction(Exception):
 
 
 def cphase(param: float) -> CZPowGate:
-    """
-    PyQuil's CPHASE and Cirq's CZPowGate are the same up to a factor of pi.
+    """The angle parameter of pyQuil's CPHASE gate and the exponent of
+    Cirq's CZPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        A CZPowGate equivalent to a CPHASE gate of given angle.
     """
     return CZPowGate(exponent=param / np.pi)
 
 
 def cphase00(phi: float) -> MatrixGate:
-    """
-    PyQuil's CPHASE00 gate can be defined using Cirq's MatrixGate.
+    """PyQuil's CPHASE00 gate can be defined using Cirq's MatrixGate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE00 gate of given angle.
     """
     cphase00_matrix = np.array([[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0],
                                 [0, 0, 1, 0], [0, 0, 0, 1]])
@@ -83,8 +94,13 @@ def cphase00(phi: float) -> MatrixGate:
 
 
 def cphase01(phi: float) -> MatrixGate:
-    """
-    PyQuil's CPHASE01 gate can be defined using Cirq's MatrixGate.
+    """PyQuil's CPHASE01 gate can be defined using Cirq's MatrixGate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE01 gate of given angle.
     """
     cphase01_matrix = np.array([[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0],
                                 [0, 0, 1, 0], [0, 0, 0, 1]])
@@ -92,8 +108,13 @@ def cphase01(phi: float) -> MatrixGate:
 
 
 def cphase10(phi: float) -> MatrixGate:
-    """
-    PyQuil's CPHASE10 gate can be defined using Cirq's MatrixGate.
+    """PyQuil's CPHASE10 gate can be defined using Cirq's MatrixGate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE10 gate of given angle.
     """
     cphase10_matrix = np.array([[1, 0, 0, 0], [0, 1, 0, 0],
                                 [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]])
@@ -101,15 +122,26 @@ def cphase10(phi: float) -> MatrixGate:
 
 
 def phase(param: float) -> ZPowGate:
-    """
-    PyQuil's PHASE and Cirq's ZPowGate are the same up to a factor of pi.
+    """The angle parameter of pyQuil's PHASE gate and the exponent of
+    Cirq's ZPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        A ZPowGate equivalent to a PHASE gate of given angle.
     """
     return ZPowGate(exponent=param / np.pi)
 
 
 def pswap(phi: float) -> MatrixGate:
-    """
-    PyQuil's PSWAP gate can be defined using Cirq's MatrixGate.
+    """PyQuil's PSWAP gate can be defined using Cirq's MatrixGate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a PSWAP gate of given angle.
     """
     pswap_matrix = np.array([
         [1, 0, 0, 0],
@@ -121,8 +153,14 @@ def pswap(phi: float) -> MatrixGate:
 
 
 def xy(param: float) -> ISwapPowGate:
-    """
-    PyQuil's XY and Cirq's ISwapPowGate are the same up to a factor of pi.
+    """The angle parameter of pyQuil's XY gate and the exponent of
+    Cirq's ISwapPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        An ISwapPowGate equivalent to an XY gate of given angle.
     """
     return ISwapPowGate(exponent=param / np.pi)
 
@@ -166,8 +204,16 @@ SUPPORTED_GATES: Dict[str, Union[Gate, Callable[..., Gate]]] = {
 
 
 def circuit_from_quil(quil: str) -> Circuit:
-    """
-    Convert a Quil program to a Cirq Circuit.
+    """Convert a Quil program to a Cirq Circuit.
+
+    Args:
+        quil: The Quil program to convert.
+
+    Returns:
+        A Cirq Circuit generated from the Quil program.
+
+    References:
+        https://github.com/rigetti/pyquil
     """
     circuit = Circuit()
     defgates = {}

--- a/cirq/contrib/quil_import/quil_test.py
+++ b/cirq/contrib/quil_import/quil_test.py
@@ -1,0 +1,84 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from cirq import Circuit, LineQubit
+from cirq.contrib.quil_import.quil import circuit_from_quil, cphase, xy
+from cirq.ops import (CCNOT, CNOT, CSWAP, CZ, H, I, ISWAP,
+                      MeasurementGate, S, SWAP, T, X, Y, Z,
+                      rx, ry, rz)
+
+QUIL_PROGRAM = """
+DECLARE ro BIT[3]
+I 0
+I 1
+I 2
+X 0
+Y 1
+Z 2
+H 0
+S 1
+T 2
+PHASE(pi/8) 0
+PHASE(pi/8) 1
+PHASE(pi/8) 2
+RX(pi/2) 0
+RY(pi/2) 1
+RZ(pi/2) 2
+CZ 0 1
+CNOT 1 2
+CPHASE(pi/2) 0 1
+SWAP 1 2
+ISWAP 0 1
+XY(pi/2) 1 2
+CCNOT 0 1 2
+CSWAP 0 1 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]
+"""
+
+
+def test_circuit_from_quil():
+    q0, q1, q2 = LineQubit.range(3)
+    cirq_circuit = Circuit([I(q0),
+                            I(q1),
+                            I(q2),
+                            X(q0),
+                            Y(q1),
+                            Z(q2),
+                            H(q0),
+                            S(q1),
+                            T(q2),
+                            Z(q0)**(1/8),
+                            Z(q1)**(1/8),
+                            Z(q2)**(1/8),
+                            rx(np.pi/2)(q0),
+                            ry(np.pi/2)(q1),
+                            rz(np.pi/2)(q2),
+                            CZ(q0, q1),
+                            CNOT(q1, q2),
+                            cphase(np.pi/2)(q0, q1),
+                            SWAP(q1, q2),
+                            ISWAP(q0, q1),
+                            xy(np.pi/2)(q1, q2),
+                            CCNOT(q0, q1, q2),
+                            CSWAP(q0, q1, q2),
+                            MeasurementGate(1, key="ro[0]")(q0),
+                            MeasurementGate(1, key="ro[1]")(q1),
+                            MeasurementGate(1, key="ro[2]")(q2)])
+
+    quil_circuit = circuit_from_quil(QUIL_PROGRAM)
+    assert cirq_circuit == quil_circuit

--- a/cirq/contrib/quil_import/quil_test.py
+++ b/cirq/contrib/quil_import/quil_test.py
@@ -47,7 +47,6 @@ from cirq.ops import (
     rz,
 )
 
-
 QUIL_PROGRAM = """
 DECLARE ro BIT[3]
 I 0
@@ -85,40 +84,38 @@ MEASURE 2 ro[2]
 
 def test_circuit_from_quil():
     q0, q1, q2 = LineQubit.range(3)
-    cirq_circuit = Circuit(
-        [
-            I(q0),
-            I(q1),
-            I(q2),
-            X(q0),
-            Y(q1),
-            Z(q2),
-            H(q0),
-            S(q1),
-            T(q2),
-            Z(q0) ** (1 / 8),
-            Z(q1) ** (1 / 8),
-            Z(q2) ** (1 / 8),
-            rx(np.pi / 2)(q0),
-            ry(np.pi / 2)(q1),
-            rz(np.pi / 2)(q2),
-            CZ(q0, q1),
-            CNOT(q1, q2),
-            cphase(np.pi / 2)(q0, q1),
-            cphase00(np.pi / 2)(q1, q2),
-            cphase01(np.pi / 2)(q0, q1),
-            cphase10(np.pi / 2)(q1, q2),
-            ISWAP(q0, q1),
-            pswap(np.pi / 2)(q1, q2),
-            SWAP(q0, q1),
-            xy(np.pi / 2)(q1, q2),
-            CCNOT(q0, q1, q2),
-            CSWAP(q0, q1, q2),
-            MeasurementGate(1, key="ro[0]")(q0),
-            MeasurementGate(1, key="ro[1]")(q1),
-            MeasurementGate(1, key="ro[2]")(q2),
-        ]
-    )
+    cirq_circuit = Circuit([
+        I(q0),
+        I(q1),
+        I(q2),
+        X(q0),
+        Y(q1),
+        Z(q2),
+        H(q0),
+        S(q1),
+        T(q2),
+        Z(q0)**(1 / 8),
+        Z(q1)**(1 / 8),
+        Z(q2)**(1 / 8),
+        rx(np.pi / 2)(q0),
+        ry(np.pi / 2)(q1),
+        rz(np.pi / 2)(q2),
+        CZ(q0, q1),
+        CNOT(q1, q2),
+        cphase(np.pi / 2)(q0, q1),
+        cphase00(np.pi / 2)(q1, q2),
+        cphase01(np.pi / 2)(q0, q1),
+        cphase10(np.pi / 2)(q1, q2),
+        ISWAP(q0, q1),
+        pswap(np.pi / 2)(q1, q2),
+        SWAP(q0, q1),
+        xy(np.pi / 2)(q1, q2),
+        CCNOT(q0, q1, q2),
+        CSWAP(q0, q1, q2),
+        MeasurementGate(1, key="ro[0]")(q0),
+        MeasurementGate(1, key="ro[1]")(q1),
+        MeasurementGate(1, key="ro[2]")(q2),
+    ])
     # build the same Circuit, using Quil
     quil_circuit = circuit_from_quil(QUIL_PROGRAM)
     # test Circuit equivalence
@@ -128,9 +125,8 @@ def test_circuit_from_quil():
     # drop declare and measures, get Program unitary
     pyquil_unitary = program_unitary(pyquil_circuit[1:-3], n_qubits=3)
     # fix qubit order convention
-    cirq_circuit_swapped = Circuit(
-        SWAP(q0, q2), cirq_circuit[:-1], SWAP(q0, q2)
-    )
+    cirq_circuit_swapped = Circuit(SWAP(q0, q2), cirq_circuit[:-1],
+                                   SWAP(q0, q2))
     # get Circuit unitary
     cirq_unitary = cirq_circuit_swapped.unitary()
     # test unitary equivalence

--- a/cirq/contrib/quil_import/quil_test.py
+++ b/cirq/contrib/quil_import/quil_test.py
@@ -14,11 +14,39 @@
 
 import numpy as np
 
+from pyquil import Program
+from pyquil.simulation.tools import program_unitary
+
 from cirq import Circuit, LineQubit
-from cirq.contrib.quil_import.quil import circuit_from_quil, cphase, xy
-from cirq.ops import (CCNOT, CNOT, CSWAP, CZ, H, I, ISWAP,
-                      MeasurementGate, S, SWAP, T, X, Y, Z,
-                      rx, ry, rz)
+from cirq.contrib.quil_import.quil import (
+    circuit_from_quil,
+    cphase,
+    cphase00,
+    cphase01,
+    cphase10,
+    pswap,
+    xy,
+)
+from cirq.ops import (
+    CCNOT,
+    CNOT,
+    CSWAP,
+    CZ,
+    H,
+    I,
+    ISWAP,
+    MeasurementGate,
+    S,
+    SWAP,
+    T,
+    X,
+    Y,
+    Z,
+    rx,
+    ry,
+    rz,
+)
+
 
 QUIL_PROGRAM = """
 DECLARE ro BIT[3]
@@ -40,8 +68,12 @@ RZ(pi/2) 2
 CZ 0 1
 CNOT 1 2
 CPHASE(pi/2) 0 1
-SWAP 1 2
+CPHASE00(pi/2) 1 2
+CPHASE01(pi/2) 0 1
+CPHASE10(pi/2) 1 2
 ISWAP 0 1
+PSWAP(pi/2) 1 2
+SWAP 0 1
 XY(pi/2) 1 2
 CCNOT 0 1 2
 CSWAP 0 1 2
@@ -53,32 +85,70 @@ MEASURE 2 ro[2]
 
 def test_circuit_from_quil():
     q0, q1, q2 = LineQubit.range(3)
-    cirq_circuit = Circuit([I(q0),
-                            I(q1),
-                            I(q2),
-                            X(q0),
-                            Y(q1),
-                            Z(q2),
-                            H(q0),
-                            S(q1),
-                            T(q2),
-                            Z(q0)**(1/8),
-                            Z(q1)**(1/8),
-                            Z(q2)**(1/8),
-                            rx(np.pi/2)(q0),
-                            ry(np.pi/2)(q1),
-                            rz(np.pi/2)(q2),
-                            CZ(q0, q1),
-                            CNOT(q1, q2),
-                            cphase(np.pi/2)(q0, q1),
-                            SWAP(q1, q2),
-                            ISWAP(q0, q1),
-                            xy(np.pi/2)(q1, q2),
-                            CCNOT(q0, q1, q2),
-                            CSWAP(q0, q1, q2),
-                            MeasurementGate(1, key="ro[0]")(q0),
-                            MeasurementGate(1, key="ro[1]")(q1),
-                            MeasurementGate(1, key="ro[2]")(q2)])
-
+    cirq_circuit = Circuit(
+        [
+            I(q0),
+            I(q1),
+            I(q2),
+            X(q0),
+            Y(q1),
+            Z(q2),
+            H(q0),
+            S(q1),
+            T(q2),
+            Z(q0) ** (1 / 8),
+            Z(q1) ** (1 / 8),
+            Z(q2) ** (1 / 8),
+            rx(np.pi / 2)(q0),
+            ry(np.pi / 2)(q1),
+            rz(np.pi / 2)(q2),
+            CZ(q0, q1),
+            CNOT(q1, q2),
+            cphase(np.pi / 2)(q0, q1),
+            cphase00(np.pi / 2)(q1, q2),
+            cphase01(np.pi / 2)(q0, q1),
+            cphase10(np.pi / 2)(q1, q2),
+            ISWAP(q0, q1),
+            pswap(np.pi / 2)(q1, q2),
+            SWAP(q0, q1),
+            xy(np.pi / 2)(q1, q2),
+            CCNOT(q0, q1, q2),
+            CSWAP(q0, q1, q2),
+            MeasurementGate(1, key="ro[0]")(q0),
+            MeasurementGate(1, key="ro[1]")(q1),
+            MeasurementGate(1, key="ro[2]")(q2),
+        ]
+    )
+    # build the same Circuit, using Quil
     quil_circuit = circuit_from_quil(QUIL_PROGRAM)
+    # test Circuit equivalence
     assert cirq_circuit == quil_circuit
+
+    pyquil_circuit = Program(QUIL_PROGRAM)
+    # drop declare and measures, get Program unitary
+    pyquil_unitary = program_unitary(pyquil_circuit[1:-3], n_qubits=3)
+    # fix qubit order convention
+    cirq_circuit_swapped = Circuit(
+        SWAP(q0, q2), cirq_circuit[:-1], SWAP(q0, q2)
+    )
+    # get Circuit unitary
+    cirq_unitary = cirq_circuit_swapped.unitary()
+    # test unitary equivalence
+    assert np.isclose(pyquil_unitary, cirq_unitary).all()
+
+
+QUIL_PROGRAM_WITH_DEFGATE = """
+DEFGATE MYZ:
+    1,0
+    0,-1
+
+X 0
+MYZ 0
+"""
+
+
+def test_quil_with_defgate():
+    q0 = LineQubit(0)
+    cirq_circuit = Circuit([X(q0), Z(q0)])
+    quil_circuit = circuit_from_quil(QUIL_PROGRAM_WITH_DEFGATE)
+    assert np.isclose(quil_circuit.unitary(), cirq_circuit.unitary()).all()

--- a/cirq/contrib/quil_import/quil_test.py
+++ b/cirq/contrib/quil_import/quil_test.py
@@ -20,8 +20,8 @@ from pyquil.simulation.tools import program_unitary
 
 from cirq import Circuit, LineQubit
 from cirq.contrib.quil_import.quil import (
+    UndefinedQuilGate,
     UnsupportedQuilInstruction,
-    UnsupportedQuilGate,
     circuit_from_quil,
     cphase,
     cphase00,
@@ -177,9 +177,12 @@ def test_unsupported_quil_instruction():
         circuit_from_quil(QUIL_PROGRAM_WITH_PARAMETERIZED_DEFGATE)
 
 
-def test_unsupported_quil_gate():
-    with pytest.raises(UnsupportedQuilGate):
+def test_undefined_quil_gate():
+    """There are no such things as FREDKIN & TOFFOLI in Quil. The standard
+    names for those gates in Quil are CSWAP and CCNOT. Of course, they can
+    be defined via DEFGATE / DEFCIRCUIT."""
+    with pytest.raises(UndefinedQuilGate):
         circuit_from_quil("FREDKIN 0 1 2")
 
-    with pytest.raises(UnsupportedQuilGate):
+    with pytest.raises(UndefinedQuilGate):
         circuit_from_quil("TOFFOLI 0 1 2")

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -216,7 +216,8 @@ class XPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('X {0}\n', qubits[0])
-        return formatter.format('RX({0}) {1}\n', self._exponent * np.pi, qubits[0])
+        return formatter.format('RX({0}) {1}\n', self._exponent * np.pi,
+                                qubits[0])
 
     @property
     def phase_exponent(self):
@@ -387,7 +388,8 @@ class YPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('Y {0}\n', qubits[0])
-        return formatter.format('RY({0}) {1}\n', self._exponent * np.pi, qubits[0])
+        return formatter.format('RY({0}) {1}\n', self._exponent * np.pi,
+                                qubits[0])
 
     @property
     def phase_exponent(self):
@@ -620,7 +622,8 @@ class ZPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('Z {0}\n', qubits[0])
-        return formatter.format('RZ({0}) {1}\n', self._exponent * np.pi, qubits[0])
+        return formatter.format('RZ({0}) {1}\n', self._exponent * np.pi,
+                                qubits[0])
 
     def __str__(self) -> str:
         if self._global_shift == -0.5:
@@ -800,8 +803,9 @@ class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('H {0}\n', qubits[0])
-        return formatter.format('RY({0}) {3}\nRX({1}) {3}\nRY({2}) {3}\n', 0.25 * np.pi,
-                                self._exponent * np.pi, -0.25 * np.pi, qubits[0])
+        return formatter.format('RY({0}) {3}\nRX({1}) {3}\nRY({2}) {3}\n',
+                                0.25 * np.pi, self._exponent * np.pi,
+                                -0.25 * np.pi, qubits[0])
 
     def _has_stabilizer_effect_(self) -> Optional[bool]:
         if self._is_parameterized_():

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -216,7 +216,7 @@ class XPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('X {0}\n', qubits[0])
-        return formatter.format('RX({0}) {1}\n', self._exponent, qubits[0])
+        return formatter.format('RX({0}) {1}\n', self._exponent * np.pi, qubits[0])
 
     @property
     def phase_exponent(self):
@@ -387,7 +387,7 @@ class YPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('Y {0}\n', qubits[0])
-        return formatter.format('RY({0}) {1}\n', self._exponent, qubits[0])
+        return formatter.format('RY({0}) {1}\n', self._exponent * np.pi, qubits[0])
 
     @property
     def phase_exponent(self):
@@ -620,8 +620,7 @@ class ZPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('Z {0}\n', qubits[0])
-
-        return formatter.format('RZ({0}) {1}\n', self._exponent, qubits[0])
+        return formatter.format('RZ({0}) {1}\n', self._exponent * np.pi, qubits[0])
 
     def __str__(self) -> str:
         if self._global_shift == -0.5:
@@ -801,8 +800,8 @@ class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('H {0}\n', qubits[0])
-        return formatter.format('RY({0}) {3}\nRX({1}) {3}\nRY({2}) {3}\n', 0.25,
-                                self._exponent, -0.25, qubits[0])
+        return formatter.format('RY({0}) {3}\nRX({1}) {3}\nRY({2}) {3}\n', 0.25 * np.pi,
+                                self._exponent * np.pi, -0.25 * np.pi, qubits[0])
 
     def _has_stabilizer_effect_(self) -> Optional[bool]:
         if self._is_parameterized_():
@@ -978,7 +977,7 @@ class CZPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('CZ {0} {1}\n', qubits[0], qubits[1])
-        return formatter.format('CPHASE({0}) {1} {2}\n', self._exponent,
+        return formatter.format('CPHASE({0}) {1} {2}\n', self._exponent * np.pi,
                                 qubits[0], qubits[1])
 
     def _has_stabilizer_effect_(self) -> Optional[bool]:

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -94,8 +94,9 @@ class XXPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('X {0}\nX {1}\n', qubits[0], qubits[1])
-        return formatter.format('RX({0}) {1}\nRX({2}) {3}\n', self._exponent,
-                                qubits[0], self._exponent, qubits[1])
+        return formatter.format('RX({0}) {1}\nRX({2}) {3}\n',
+                                self._exponent * np.pi, qubits[0],
+                                self._exponent * np.pi, qubits[1])
 
     def __str__(self) -> str:
         if self.exponent == 1:
@@ -168,8 +169,9 @@ class YYPowGate(eigen_gate.EigenGate,
         if self._exponent == 1:
             return formatter.format('Y {0}\nY {1}\n', qubits[0], qubits[1])
 
-        return formatter.format('RY({0}) {1}\nRY({2}) {3}\n', self._exponent,
-                                qubits[0], self._exponent, qubits[1])
+        return formatter.format('RY({0}) {1}\nRY({2}) {3}\n',
+                                self._exponent * np.pi, qubits[0],
+                                self._exponent * np.pi, qubits[1])
 
     def __str__(self) -> str:
         if self._exponent == 1:
@@ -249,8 +251,9 @@ class ZZPowGate(eigen_gate.EigenGate,
         if self._exponent == 1:
             return formatter.format('Z {0}\nZ {1}\n', qubits[0], qubits[1])
 
-        return formatter.format('RZ({0}) {1}\nRZ({2}) {3}\n', self._exponent,
-                                qubits[0], self._exponent, qubits[1])
+        return formatter.format('RZ({0}) {1}\nRZ({2}) {3}\n',
+                                self._exponent * np.pi, qubits[0],
+                                self._exponent * np.pi, qubits[1])
 
     def __str__(self) -> str:
         if self._exponent == 1:

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -131,7 +131,7 @@ class SwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('SWAP {0} {1}\n', qubits[0], qubits[1])
-        return formatter.format('PSWAP({0}) {1} {2}\n', self._exponent,
+        return formatter.format('PSWAP({0}) {1} {2}\n', self._exponent * np.pi,
                                 qubits[0], qubits[1])
 
     def __str__(self) -> str:

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -262,7 +262,8 @@ class ISwapPowGate(eigen_gate.EigenGate,
                formatter: 'cirq.QuilFormatter') -> Optional[str]:
         if self._exponent == 1:
             return formatter.format('ISWAP {0} {1}\n', qubits[0], qubits[1])
-        return None  #ISwap with rotation not supported in Quil
+        return formatter.format('XY({0}) {1} {2}\n', self._exponent * np.pi,
+                                qubits[0], qubits[1])
 
 
 def riswap(rads: value.TParamVal) -> ISwapPowGate:

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -5,7 +5,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # 3rd-party libs for which we don't have stubs
-[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*]
+[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*,pyquil.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -14,6 +14,9 @@ mypy-protobuf==1.10
 # For uploading packages to pypi.
 twine
 
+# For verifying behavior of Quil output.
+pyquil~=2.21.0
+
 # For verifying behavior of qasm output.
 qiskit~=0.13.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -553,6 +553,7 @@ contrib may change without notice.
     cirq.contrib.acquaintance
     cirq.contrib.paulistring
     cirq.contrib.qcircuit
+    cirq.contrib.quil_import
     cirq.contrib.quirk
 
 


### PR DESCRIPTION
```python
In [1]: from cirq.contrib.quil_import import circuit_from_quil

In [2]: circuit_from_quil("""
   ...: I 0
   ...: I 1
   ...: I 2
   ...: X 0
   ...: Y 1
   ...: Z 2
   ...: H 0
   ...: S 1
   ...: T 2
   ...: PHASE(pi/8) 0
   ...: PHASE(pi/8) 1
   ...: PHASE(pi/8) 2
   ...: RX(pi/2) 0
   ...: RY(pi/2) 1
   ...: RZ(pi/2) 2
   ...: CZ 0 1
   ...: CNOT 1 2
   ...: CPHASE(pi/2) 0 1
   ...: SWAP 1 2
   ...: ISWAP 0 1
   ...: XY(pi/2) 1 2
   ...: CCNOT 0 1 2
   ...: CSWAP 0 1 2
   ...: MEASURE 0 ro[0]
   ...: MEASURE 1 ro[1]
   ...: MEASURE 2 ro[2]
   ...: """)
Out[2]:
0: ───I───X───H───Z^(1/8)───Rx(0.5π)───@───────@───────────iSwap───────────────@───@───M('ro[0]')───
                                       │       │           │                   │   │
1: ───I───Y───S───Z^(1/8)───Ry(0.5π)───@───@───@^0.5───×───iSwap───iSwap───────@───×───M('ro[1]')───
                                           │           │           │           │   │
2: ───I───Z───T───Z^(1/8)───Rz(0.5π)───────X───────────×───────────iSwap^0.5───X───×───M('ro[2]')───
```